### PR TITLE
Bug fix of enter key press in todo form

### DIFF
--- a/Frontend/src/components/Todos/TaskInput.tsx
+++ b/Frontend/src/components/Todos/TaskInput.tsx
@@ -27,6 +27,7 @@ const TaskInput: React.FC<TaskInputProps> = ({
       </Form.Group>
       <Button
         variant={editingTask ? "warning" : "primary"}
+        type="submit"
         onClick={onSubmit}
         className="mt-2"
       >


### PR DESCRIPTION
Issue: The form submits when pressing the Enter key in the Todo form, leading to unintended form refresh.

Fix: Enable form submission on Enter key press without refreshing form.

Note: This fix ensures that users can submit the form using enter key press, improving user experience by allowing submissions with the Enter key.